### PR TITLE
ci: linux aarch64 native-image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
           command: |
             cd ~
             if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java11-linux-amd64-22.3.1.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.1.tar.gz
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
             fi
       - run:
           name: Install bb
@@ -71,7 +71,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.1
+            - ~/graalvm-ce-java11-22.3.3
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
@@ -83,7 +83,7 @@ jobs:
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.1
+      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -113,7 +113,7 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.1 ]; then
+            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
               /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
               /bin/mkdir graalvm
               /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
@@ -148,7 +148,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.1
+            - ~/graalvm-ce-java11-22.3.3
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.0
+      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -113,9 +113,14 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
+              /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
+              /bin/mkdir graalvm
+              /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
+              sudo update-alternatives --install /usr/bin/java java /home/circleci/graalvm/bin/java 0
+              sudo update-alternatives --install /usr/bin/javac javac /home/circleci/graalvm/bin/javac 0
+              sudo update-alternatives --set java /home/circleci/graalvm/bin/java
+              sudo update-alternatives --set javac /home/circleci/graalvm/bin/javac
             fi
       - run:
           name: Install bb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,8 @@ jobs:
           command: |
             cd ~
             if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
             fi
       - run:
           name: Install bb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ jobs:
   linux:
     resource_class: large
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.6-bullseye
+      - image: cimg/clojure:1.11.1-openjdk-17.0
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
+      GRAALVM_HOME: /home/circleci/graalvm-community-openjdk-21.0.2+13.1
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -25,12 +25,12 @@ jobs:
       - restore_cache:
           keys:
             - linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
-      - run:
-          name: Install Clojure
-          command: |
-            wget https://download.clojure.org/install/linux-install-1.10.3.1029.sh
-            chmod +x linux-install-1.10.3.1029.sh
-            sudo ./linux-install-1.10.3.1029.sh
+      # - run:
+      #     name: Install Clojure
+      #     command: |
+      #       wget https://download.clojure.org/install/linux-install-1.10.3.1029.sh
+      #       chmod +x linux-install-1.10.3.1029.sh
+      #       sudo ./linux-install-1.10.3.1029.sh
       - run:
           name: Install native dev tools
           command: |
@@ -41,16 +41,16 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+            if ! [ -d graalvm-community-openjdk-21.0.2+13.1 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz
+              tar xzf graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz
             fi
-      - run:
-          name: Install bb
-          command: |
-            bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir $(pwd) --dev-build
-            sudo mv bb /usr/local/bin
-            bb --version
+      # - run:
+      #     name: Install bb
+      #     command: |
+      #       bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir $(pwd) --dev-build
+      #       sudo mv bb /usr/local/bin
+      #       bb --version
       - run:
           name: Build binary
           command: |
@@ -71,7 +71,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.3
+            - ~/graalvm-community-openjdk-21.0.2+13.1
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
@@ -83,7 +83,7 @@ jobs:
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
+      GRAALVM_HOME: /home/circleci/graalvm-community-openjdk-21.0.2+13.1
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -113,9 +113,9 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
+            if ! [ -d graalvm-community-openjdk-21.0.2+13.1 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
+              tar xzf graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
             fi
       - run:
           name: Install bb
@@ -143,7 +143,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.3
+            - ~/graalvm-community-openjdk-21.0.2+13.1
           key: linux-aarch64-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
@@ -153,7 +153,7 @@ jobs:
       xcode: "14.0.0"
     resource_class: large
     environment:
-      GRAALVM_HOME: /Users/distiller/graalvm-ce-java11-22.3.3/Contents/Home
+      GRAALVM_HOME: /Users/distiller/graalvm-community-openjdk-21.0.2+13.1/Contents/Home
       APP_PLATFORM: macos # used in release script
       APP_TEST_ENV: native
     steps:
@@ -179,9 +179,9 @@ jobs:
           command: |
             cd ~
             ls -la
-            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-darwin-amd64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-darwin-amd64-22.3.3.tar.gz
+            if ! [ -d graalvm-community-openjdk-21.0.2+13.1 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_macos-x64_bin.tar.gz
+              tar xzf graalvm-community-jdk-21.0.2_macos-x64_bin.tar.gz
             fi
       - run:
           name: Install bb
@@ -208,14 +208,14 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.3
+            - ~/graalvm-community-openjdk-21.0.2+13.1
           key: mac-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
           destination: release
   deploy:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.6-bullseye
+      - image: cimg/clojure:1.11.1-openjdk-17.0
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
           command: |
             cd ~
             if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java11-linux-amd64-22.3.1.tar.gz
+              tar xzf graalvm-ce-java11-linux-amd64-22.3.1.tar.gz
             fi
       - run:
           name: Install bb
@@ -71,7 +71,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.3
+            - ~/graalvm-ce-java11-22.3.1
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
@@ -83,7 +83,7 @@ jobs:
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
+      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.1
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -113,7 +113,7 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
+            if ! [ -d graalvm-ce-java11-22.3.1 ]; then
               /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
               /bin/mkdir graalvm
               /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
@@ -148,7 +148,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.3
+            - ~/graalvm-ce-java11-22.3.1
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
+            - linux-aarch64-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - run:
           name: Install Clojure
           command: |
@@ -113,7 +113,7 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
+            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
               curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
               tar xzf graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
             fi
@@ -144,7 +144,7 @@ jobs:
           paths:
             - ~/.m2
             - ~/graalvm-ce-java11-22.3.3
-          key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
+          key: linux-aarch64-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release
           destination: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,14 +113,13 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
-              /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz
-              /bin/mkdir graalvm
-              /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
-              sudo update-alternatives --install /usr/bin/java java /home/circleci/graalvm/bin/java 0
-              sudo update-alternatives --install /usr/bin/javac javac /home/circleci/graalvm/bin/javac 0
-              sudo update-alternatives --set java /home/circleci/graalvm/bin/java
-              sudo update-alternatives --set javac /home/circleci/graalvm/bin/javac
+            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              sudo update-alternatives --install /usr/bin/java java /home/circleci/graalvm-ce-java11-22.3.3/bin/java 0
+              sudo update-alternatives --install /usr/bin/javac javac /home/circleci/graalvm-ce-java11-22.3.3/bin/javac 0
+              sudo update-alternatives --set java /home/circleci/graalvm-ce-java11-22.3.3/bin/java
+              sudo update-alternatives --set javac /home/circleci/graalvm-ce-java11-22.3.3/bin/javac
             fi
       - run:
           name: Install bb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
-      BABASHKA_MUSL: true
+      BABASHKA_MUSL: false
     steps:
       - run:
           name: Get rid of erroneous git config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
           command: |
             cd ~
             if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-linux-amd64-22.3.0.tar.gz
-              tar xzf graalvm-ce-java11-linux-amd64-22.3.0.tar.gz
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
             fi
       - run:
           name: Install bb
@@ -71,7 +71,79 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.0
+            - ~/graalvm-ce-java11-22.3.3
+          key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
+      - store_artifacts:
+          path: /tmp/release
+          destination: release
+  linux-aarch64:
+    resource_class: arm.large
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.6-bullseye
+    working_directory: ~/repo
+    environment:
+      LEIN_ROOT: "true"
+      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.0
+      APP_PLATFORM: linux # used in release script
+      APP_TEST_ENV: native
+      BABASHKA_STATIC: true
+      BABASHKA_MUSL: true
+    steps:
+      - run:
+          name: Get rid of erroneous git config
+          command: |
+              rm -rf /home/circleci/.gitconfig
+      - checkout
+      - restore_cache:
+          keys:
+            - linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
+      - run:
+          name: Install Clojure
+          command: |
+            wget https://download.clojure.org/install/linux-install-1.10.3.1029.sh
+            chmod +x linux-install-1.10.3.1029.sh
+            sudo ./linux-install-1.10.3.1029.sh
+      - run:
+          name: Install native dev tools
+          command: |
+            sudo apt-get update
+            sudo apt-get -y install gcc g++ zlib1g-dev
+            sudo -E script/setup-musl
+      - run:
+          name: Download GraalVM
+          command: |
+            cd ~
+            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-aarch64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
+            fi
+      - run:
+          name: Install bb
+          command: |
+            bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir $(pwd) --dev-build
+            sudo mv bb /usr/local/bin
+            bb --version
+      - run:
+          name: Build binary
+          command: |
+            bb script/compile.clj
+          no_output_timeout: 30m
+      - run:
+          name: Run tests
+          command: |
+            bb script/test.clj
+      # - run:
+      #     name: Performance report
+      #     command: |
+      #       .circleci/script/performance
+      - run:
+          name: Release
+          command: |
+            .circleci/script/release
+      - save_cache:
+          paths:
+            - ~/.m2
+            - ~/graalvm-ce-java11-22.3.3
           key: linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,9 @@ jobs:
           destination: release
   linux-aarch64:
     resource_class: arm.large
-    docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.6-bullseye
+    machine:
+      image: ubuntu-2204:2023.10.1
+      resource_class: arm.large
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,7 @@ workflows:
     jobs:
 #      - jvm
       - linux
+      - linux-aarch64
       - mac
       - deploy:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
-      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.0
+      GRAALVM_HOME: /home/circleci/graalvm-ce-java11-22.3.3
       APP_PLATFORM: linux # used in release script
       APP_TEST_ENV: native
       BABASHKA_STATIC: true
@@ -41,7 +41,7 @@ jobs:
           name: Download GraalVM
           command: |
             cd ~
-            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
+            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
               curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
               tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
             fi
@@ -153,7 +153,7 @@ jobs:
       xcode: "14.0.0"
     resource_class: large
     environment:
-      GRAALVM_HOME: /Users/distiller/graalvm-ce-java11-22.3.0/Contents/Home
+      GRAALVM_HOME: /Users/distiller/graalvm-ce-java11-22.3.3/Contents/Home
       APP_PLATFORM: macos # used in release script
       APP_TEST_ENV: native
     steps:
@@ -179,9 +179,9 @@ jobs:
           command: |
             cd ~
             ls -la
-            if ! [ -d graalvm-ce-java11-22.3.0 ]; then
-              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-darwin-amd64-22.3.0.tar.gz
-              tar xzf graalvm-ce-java11-darwin-amd64-22.3.0.tar.gz
+            if ! [ -d graalvm-ce-java11-22.3.3 ]; then
+              curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-darwin-amd64-22.3.3.tar.gz
+              tar xzf graalvm-ce-java11-darwin-amd64-22.3.3.tar.gz
             fi
       - run:
           name: Install bb
@@ -208,7 +208,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-            - ~/graalvm-ce-java11-22.3.0
+            - ~/graalvm-ce-java11-22.3.3
           key: mac-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: /tmp/release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,10 +116,6 @@ jobs:
             if ! [ -d graalvm-ce-java11-22.3.0 ]; then
               curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
               tar xzf graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
-              sudo update-alternatives --install /usr/bin/java java /home/circleci/graalvm-ce-java11-22.3.3/bin/java 0
-              sudo update-alternatives --install /usr/bin/javac javac /home/circleci/graalvm-ce-java11-22.3.3/bin/javac 0
-              sudo update-alternatives --set java /home/circleci/graalvm-ce-java11-22.3.3/bin/java
-              sudo update-alternatives --set javac /home/circleci/graalvm-ce-java11-22.3.3/bin/javac
             fi
       - run:
           name: Install bb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,6 @@ jobs:
       - restore_cache:
           keys:
             - linux-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
-      # - run:
-      #     name: Install Clojure
-      #     command: |
-      #       wget https://download.clojure.org/install/linux-install-1.10.3.1029.sh
-      #       chmod +x linux-install-1.10.3.1029.sh
-      #       sudo ./linux-install-1.10.3.1029.sh
       - run:
           name: Install native dev tools
           command: |
@@ -45,12 +39,12 @@ jobs:
               curl -O -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz
               tar xzf graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz
             fi
-      # - run:
-      #     name: Install bb
-      #     command: |
-      #       bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir $(pwd) --dev-build
-      #       sudo mv bb /usr/local/bin
-      #       bb --version
+      - run:
+          name: Install bb
+          command: |
+            # bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir $(pwd) --dev-build
+            # sudo mv bb /usr/local/bin
+            bb --version
       - run:
           name: Build binary
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
           path: /tmp/release
           destination: release
   linux-aarch64:
-    resource_class: arm.large
     machine:
       image: ubuntu-2204:2023.10.1
       resource_class: arm.large

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ macos_instance:
 
 task:
   env:
-    GRAALVM_VERSION: "22.3.1"
-    GRAALVM_HOME: ${HOME}/graalvm-ce-java19-22.3.1/Contents/Home
+    GRAALVM_VERSION: "21.0.2"
+    GRAALVM_HOME: ${HOME}/graalvm-community-openjdk-21.0.2+13.1/Contents/Home
     TDN_PLATFORM: macos # used in release script
     TDN_ARCH: aarch64
     TDN_TEST_ENV: native

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ task:
     bb script/compile.clj
     bb script/test.clj
 
-    VERSION=$(cat resources/TDN_VERSION)
+    VERSION=$(cat resources/META-INF/borkdude/tools-deps-native/version.txt)
     archive="tools-deps-native-${VERSION}-${TDN_PLATFORM}-${TDN_ARCH:-amd64}.tar.gz"
     tar zcvf "$archive" tools-deps-native
     bb release-artifact "$archive" || true

--- a/script/compile.clj
+++ b/script/compile.clj
@@ -10,8 +10,6 @@
 (def app_name "tools-deps-native")
 (def app_ns "borkdude.tdn.main")
 
-(shell (native-bin "gu") "install" "native-image")
-
 (fs/delete-tree "classes")
 (fs/delete-tree "tools-deps-native")
 (fs/create-dir "classes")

--- a/script/compile.clj
+++ b/script/compile.clj
@@ -10,7 +10,7 @@
 (def app_name "tools-deps-native")
 (def app_ns "borkdude.tdn.main")
 
-#_(shell (native-bin "gu") "install" "native-image")
+(shell (native-bin "gu") "install" "native-image")
 
 (fs/delete-tree "classes")
 (fs/delete-tree "tools-deps-native")

--- a/script/compile.clj
+++ b/script/compile.clj
@@ -10,7 +10,7 @@
 (def app_name "tools-deps-native")
 (def app_ns "borkdude.tdn.main")
 
-(shell (native-bin "gu") "install" "native-image")
+#_(shell (native-bin "gu") "install" "native-image")
 
 (fs/delete-tree "classes")
 (fs/delete-tree "tools-deps-native")

--- a/script/install-clojure
+++ b/script/install-clojure
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CLOJURE_TOOLS_VERSION="1.10.3.1040"
+CLOJURE_TOOLS_VERSION="1.11.1.1435"
 
 install_dir="${1:-/usr/local}"
 mkdir -p "$install_dir"

--- a/script/install-graalvm
+++ b/script/install-graalvm
@@ -4,11 +4,11 @@ set -euo pipefail
 
 INSTALL_DIR="${1:-$HOME}"
 
-GRAALVM_VERSION="${GRAALVM_VERSION:-21.2.0}"
+GRAALVM_VERSION="${GRAALVM_VERSION:-21.0.2}"
 
 case "$TDN_PLATFORM" in
     macos)
-        GRAALVM_PLATFORM="darwin"
+        GRAALVM_PLATFORM="macos"
         ;;
     linux)
         GRAALVM_PLATFORM="linux"
@@ -24,17 +24,17 @@ case "${TDN_ARCH:-}" in
         ;;
 esac
 
-GRAALVM_FILENAME="graalvm-ce-java19-$GRAALVM_PLATFORM-$GRAALVM_ARCH-$GRAALVM_VERSION.tar.gz"
+GRAALVM_FILENAME="graalvm-community-jdk-${GRAALVM_VERSION}_${GRAALVM_PLATFORM}-${GRAALVM_ARCH}_bin.tar.gz"
 
 pushd "$INSTALL_DIR" >/dev/null
 
-if ! [ -d "graalvm-ce-java19-$GRAALVM_VERSION" ]; then
+if ! [ -d "graalvm-community-openjdk-21.0.2+13.1" ]; then
     echo "Downloading GraalVM $GRAALVM_PLATFORM-$GRAALVM_ARCH-$GRAALVM_VERSION on '$PWD'..."
-    echo "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/$GRAALVM_FILENAME"
-    curl -LO "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/$GRAALVM_FILENAME"
+    echo "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$GRAALVM_VERSION/$GRAALVM_FILENAME"
+    curl -LO "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$GRAALVM_VERSION/$GRAALVM_FILENAME"
     ls -la
     tar xzvf "$GRAALVM_FILENAME"
-    ls -la "graalvm-ce-java19-$GRAALVM_VERSION"
+    ls -la "graalvm-community-openjdk-21.0.2+13.1"
 fi
 
 popd >/dev/null

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -40,4 +40,4 @@ cd ..
 # Install libz.a in the correct place so ldd can find it
 install -Dm644 "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"
 
-ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc
+# ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc


### PR DESCRIPTION
With this PR I added the linux aarch64 native-image build to tools-deps-native. I've also bumped the Graalvm version to the latest jdk-11 release.

My Circleci-builds:
https://app.circleci.com/pipelines/github/TimoKramer/tools-deps-native/14/workflows/3941c3dc-f9fd-461d-b9b3-27ebd77aec59